### PR TITLE
:sparkles: Add recursive flag and default path

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,5 +7,5 @@ See [Go Concurrency Patterns: Pipelines and cancellation](https://blog.golang.or
 
 ~~~bash
 go get github.com/Kaiser925/md5tree
-md5tree <dir>
+md5tree [path] [-r]
 ~~~

--- a/md5tree.go
+++ b/md5tree.go
@@ -6,7 +6,6 @@ import (
 	"flag"
 	"fmt"
 	"io/ioutil"
-	"log"
 	"os"
 	"path/filepath"
 	"sort"
@@ -19,7 +18,7 @@ type result struct {
 	err  error
 }
 
-func walkFile(done <-chan struct{}, root string) (<-chan string, <-chan error) {
+func walkFile(done <-chan struct{}, root string, recursive bool) (<-chan string, <-chan error) {
 	paths := make(chan string)
 	errc := make(chan error, 1)
 
@@ -28,6 +27,10 @@ func walkFile(done <-chan struct{}, root string) (<-chan string, <-chan error) {
 		errc <- filepath.Walk(root, func(path string, info os.FileInfo, err error) error {
 			if err != nil {
 				return err
+			}
+
+			if info.IsDir() && !recursive && path != root {
+				return filepath.SkipDir
 			}
 
 			if !info.Mode().IsRegular() {
@@ -57,10 +60,10 @@ func digester(done <-chan struct{}, paths <-chan string, c chan<- result) {
 	}
 }
 
-func sumFile(done <-chan struct{}, root string) (<-chan result, <-chan error) {
+func sumFile(done <-chan struct{}, root string, recursive bool) (<-chan result, <-chan error) {
 	c := make(chan result)
 
-	paths, errc := walkFile(done, root)
+	paths, errc := walkFile(done, root, recursive)
 
 	var wg sync.WaitGroup
 	const numDigesters = 20
@@ -84,11 +87,11 @@ func sumFile(done <-chan struct{}, root string) (<-chan result, <-chan error) {
 // MD5All reads all the files in the file tree rooted at root and returns a map
 // from file path to the MD5 sum of the file's contents.  If the directory walk
 // fails or any read operation fails, MD5All returns an error.
-func MD5All(root string) (map[string][md5.Size]byte, error) {
+func MD5All(root string, recursive bool) (map[string][md5.Size]byte, error) {
 	done := make(chan struct{})
 	defer close(done)
 
-	c, errc := sumFile(done, root)
+	c, errc := sumFile(done, root, recursive)
 
 	m := make(map[string][md5.Size]byte)
 	for r := range c {
@@ -105,13 +108,19 @@ func MD5All(root string) (map[string][md5.Size]byte, error) {
 }
 
 func main() {
-	flag.Parse()
-	if flag.NArg() != 1 {
-		log.SetFlags(0)
-		log.Fatal("Usage: md5tree <dir>")
+	recursive := flag.Bool("r", false, "recursive")
+	flag.Usage = func() {
+		_, _ = fmt.Fprintf(os.Stderr, "Usage of md5tree: %s\n", "md5tree [path] [-r]")
+		flag.PrintDefaults()
 	}
+	flag.Parse()
+
 	dirPath := flag.Arg(0)
-	m, err := MD5All(dirPath)
+	if len(dirPath) == 0 {
+		dirPath = "."
+	}
+
+	m, err := MD5All(dirPath, *recursive)
 	if err != nil {
 		fmt.Println(err)
 		return


### PR DESCRIPTION
In the previous version, if the user did not specify the path, it will return an error and let the user specify the path. Now, if will use "." as the default path. And md5tree will not walk path recursively by default